### PR TITLE
fix base URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/ephemeral-github-action-deployer/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>EGAD - Ephemeral GitHub Action Deployer</title>
     <meta name="description" content="EGAD - Secure, zero-trust deployment to Traefik reverse proxies via Tailscale" />

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 export default defineConfig({
+  base: '/ephemeral-github-action-deployer/',
   plugins: [react()],
   build: {
     outDir: 'dist',


### PR DESCRIPTION
This pull request updates the deployment configuration to support hosting the application under the `/ephemeral-github-action-deployer/` subpath instead of the root. The changes ensure that static assets and routing work correctly when deployed to this subdirectory.

Configuration updates for subpath deployment:

* Updated the `base` option in `vite.config.js` to `/ephemeral-github-action-deployer/` so that all built assets reference the correct subpath.
* Changed the favicon path in `index.html` to `/ephemeral-github-action-deployer/vite.svg` to match the new base path.